### PR TITLE
Generic roots for BSpline and Bezier

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install system dependencies
+      run: sudo apt-get update && sudo apt-get install -y pkg-config libfontconfig1-dev
     - name: UpdateNightly
       run: rustup default nightly
     - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/dorianprill/stroke"
 readme = "README.md"
 keywords = ["point", "bezier", "spline", "graphics", "path" ]
 categories = ["no-std", "science", "graphics", "mathematics", "data-structures" ]
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # stroke  
 
-![Rust](https://github.com/dorianprill/brezel/workflows/Rust/badge.svg)
+![Rust](https://github.com/dorianprill/stroke/actions/workflows/rust.yml/badge.svg)
 ![crates.io](https://img.shields.io/crates/v/stroke.svg)
 
 A zero-allocation library providing const-generic implementations of Bézier curves, B-Spline curves and specialized implementations of up to cubic Bézier curves in N-dimensional euclidean space. It is intended for general/embedded/wasm use supporting #![no_std] environments written in 100% safe Rust with minimal dependencies.  
 
-The library makes heavy use of const-generics and some related unstabilized features, so the nightly compiler is required.  
+The library makes heavy use of const-generics and `generic_const_exprs`, so the nightly compiler is required.  
 It comes with a const-generic N-dimensional Point type so you can use the library without any other dependencies.  
+`PointN` uses the platform's `NativeFloat` (f64 on 64-bit, f32 otherwise) for its scalar operations.  
 Should you want to integrate with types provided by another library, you are able to do so by implementing the small Point trait that the library relies upon (given it makes no distinction between a point and its position vector).  
 
 ![A Cubic Bézier Curve with Bounding Box and Convex Hull rendered by plotters.rs](https://raw.githubusercontent.com/dorianprill/stroke-rs/main/cubic_bezier_bounding_box.png)  
@@ -49,7 +50,7 @@ These are the main supported features. Some further utility methods are exposed 
 - [x] arc length (linear approx.)
 - [ ] arc length (Legendre-Gauss)
 - [ ] curvature/radius (Frenet-Serret Frame)
-- [ ] bounding box
+- [x] bounding box
 - [ ] tight box
 
 ### Generic B-Splines
@@ -69,4 +70,4 @@ If you're looking for a published crate for rendering with gpu support you shoul
 
 Also, there's [Twinklebear/bspline](https://github.com/Twinklebear/bspline) which is a very clean and useful library for just bsplines. However, it depends on std and its simple Interpolate trait defines no way to access the individual dimensions of the points and hence implements no derivatives in the library.  
 
-This clear online book [A Primer on Bézier Curves](https://pomax.github.io/Bézierinfo/) helped me with a lot of the algorithms involved.
+This clear online book [A Primer on Bézier Curves](https://pomax.github.io/bezierinfo/) helped me with a lot of the algorithms involved.

--- a/examples/bezier_path.rs
+++ b/examples/bezier_path.rs
@@ -1,0 +1,29 @@
+use stroke::{BezierPath, CubicBezier, LineSegment, PointN, QuadraticBezier};
+
+fn main() {
+    let mut path: BezierPath<PointN<f64, 2>, 8> = BezierPath::new();
+
+    path.push_line(LineSegment::new(
+        PointN::new([0.0, 0.0]),
+        PointN::new([1.0, 0.0]),
+    ));
+
+    path.push_quadratic(QuadraticBezier::new(
+        PointN::new([1.0, 0.0]),
+        PointN::new([1.5, 0.8]),
+        PointN::new([2.0, 0.0]),
+    ));
+
+    path.push_cubic(CubicBezier::new(
+        PointN::new([2.0, 0.0]),
+        PointN::new([2.5, -0.6]),
+        PointN::new([3.0, 0.8]),
+        PointN::new([3.5, 0.0]),
+    ));
+
+    let sample = path.eval(0.35).unwrap();
+    println!("sample: {:?}", sample);
+
+    let bounds = path.bounding_box().unwrap();
+    println!("bounds: {:?}", bounds);
+}

--- a/examples/bspline_path.rs
+++ b/examples/bspline_path.rs
@@ -1,0 +1,33 @@
+use stroke::{BSpline, BSplinePath, PointN};
+
+fn main() {
+    let knots: [f64; 4] = [0.0, 0.0, 1.0, 1.0];
+
+    let seg1: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+        knots,
+        [
+            PointN::new([0.0, 0.0]),
+            PointN::new([1.0, 0.0]),
+        ],
+    )
+    .unwrap();
+
+    let seg2: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+        knots,
+        [
+            PointN::new([1.0, 0.0]),
+            PointN::new([1.0, 1.0]),
+        ],
+    )
+    .unwrap();
+
+    let mut path: BSplinePath<PointN<f64, 2>, 4, 2, 1, 4> = BSplinePath::new();
+    path.push(seg1);
+    path.push(seg2);
+
+    let sample = path.eval(0.6).unwrap();
+    println!("sample: {:?}", sample);
+
+    let bounds = path.bounding_box().unwrap();
+    println!("bounds: {:?}", bounds);
+}

--- a/src/bezier_segment.rs
+++ b/src/bezier_segment.rs
@@ -15,7 +15,7 @@ impl<P> BezierSegment<P>
 where
     P: Point,
 {
-    pub fn eval<F>(&self, t: P::Scalar) -> P {
+    pub fn eval(&self, t: P::Scalar) -> P {
         match self {
             BezierSegment::Linear(segment) => segment.eval(t),
             BezierSegment::Quadratic(segment) => segment.eval(t),
@@ -58,6 +58,15 @@ where
             BezierSegment::Linear(segment) => *segment,
             BezierSegment::Quadratic(segment) => segment.baseline(),
             BezierSegment::Cubic(segment) => segment.baseline(),
+        }
+    }
+
+    #[inline]
+    pub fn bounding_box(&self) -> [(P::Scalar, P::Scalar); P::DIM] {
+        match self {
+            BezierSegment::Linear(segment) => segment.bounding_box(),
+            BezierSegment::Quadratic(segment) => segment.bounding_box(),
+            BezierSegment::Cubic(segment) => segment.bounding_box(),
         }
     }
 
@@ -107,5 +116,14 @@ where
 {
     fn from(s: CubicBezier<P>) -> Self {
         BezierSegment::Cubic(s)
+    }
+}
+
+impl<P> Default for BezierSegment<P>
+where
+    P: Point,
+{
+    fn default() -> Self {
+        BezierSegment::Linear(LineSegment::new(P::default(), P::default()))
     }
 }

--- a/src/bspline_path.rs
+++ b/src/bspline_path.rs
@@ -1,0 +1,240 @@
+use core::slice;
+
+use super::*;
+
+/// A path composed of multiple B-Spline segments of the same degree/knots layout.
+pub struct BSplinePath<P, const K: usize, const C: usize, const D: usize, const N: usize>
+where
+    P: Point,
+{
+    segments: ArrayVec<[BSpline<P, K, C, D>; N]>,
+}
+
+impl<P, const K: usize, const C: usize, const D: usize, const N: usize>
+    BSplinePath<P, K, C, D, N>
+where
+    P: Point,
+    [BSpline<P, K, C, D>; N]: tinyvec::Array<Item = BSpline<P, K, C, D>>,
+{
+    pub fn new() -> Self {
+        BSplinePath {
+            segments: ArrayVec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.len() == 0
+    }
+
+    pub fn segments(&self) -> slice::Iter<'_, BSpline<P, K, C, D>> {
+        self.segments.iter()
+    }
+
+    pub fn push(&mut self, segment: BSpline<P, K, C, D>) -> bool {
+        if self.segments.len() < self.segments.capacity() {
+            self.segments.push(segment);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Evaluate a point along the path for t in [0,1]. Returns None for empty paths.
+    pub fn eval(&self, t: P::Scalar) -> Option<P>
+    where
+        [(); D + 1]: Sized,
+    {
+        let (index, local_t) = self.segment_parameter(t)?;
+        let segment = &self.segments[index];
+        let (kmin, kmax) = segment.knot_domain();
+        let t_mapped = kmin + (kmax - kmin) * local_t;
+        segment.eval(t_mapped).ok()
+    }
+
+    /// Return a conservative bounding box based on all control points.
+    /// Returns None for empty paths.
+    pub fn bounding_box(&self) -> Option<[(P::Scalar, P::Scalar); P::DIM]> {
+        let mut iter = self.segments.iter();
+        let first = match iter.next() {
+            Some(segment) => segment_control_bounds(segment),
+            None => return None,
+        };
+
+        let mut bounds = first;
+        for segment in iter {
+            let segment_bounds = segment_control_bounds(segment);
+            for dim in 0..P::DIM {
+                if segment_bounds[dim].0 < bounds[dim].0 {
+                    bounds[dim].0 = segment_bounds[dim].0;
+                }
+                if segment_bounds[dim].1 > bounds[dim].1 {
+                    bounds[dim].1 = segment_bounds[dim].1;
+                }
+            }
+        }
+
+        Some(bounds)
+    }
+
+    fn segment_parameter(&self, t: P::Scalar) -> Option<(usize, P::Scalar)> {
+        let count = self.segments.len();
+        if count == 0 {
+            return None;
+        }
+
+        let mut t_native: NativeFloat = t.into();
+        t_native = t_native.clamp(0.0, 1.0);
+
+        let count_native = count as NativeFloat;
+        let scaled = t_native * count_native;
+        if scaled >= count_native {
+            return Some((count - 1, P::Scalar::from(1.0)));
+        }
+
+        let index = scaled.floor() as usize;
+        let local = scaled - index as NativeFloat;
+        Some((index, P::Scalar::from(local)))
+    }
+}
+
+impl<P, const K: usize, const C: usize, const D: usize, const N: usize> Default
+    for BSplinePath<P, K, C, D, N>
+where
+    P: Point,
+    [BSpline<P, K, C, D>; N]: tinyvec::Array<Item = BSpline<P, K, C, D>>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn segment_control_bounds<P, const K: usize, const C: usize, const D: usize>(
+    segment: &BSpline<P, K, C, D>,
+) -> [(P::Scalar, P::Scalar); P::DIM]
+where
+    P: Point,
+{
+    let mut iter = segment.control_points();
+    let first = *iter
+        .next()
+        .expect("BSpline must have at least one control point");
+    let mut bounds = [(P::Scalar::default(), P::Scalar::default()); P::DIM];
+    for dim in 0..P::DIM {
+        let value = first.axis(dim);
+        bounds[dim] = (value, value);
+    }
+
+    for point in iter {
+        for dim in 0..P::DIM {
+            let value = point.axis(dim);
+            if value < bounds[dim].0 {
+                bounds[dim].0 = value;
+            }
+            if value > bounds[dim].1 {
+                bounds[dim].1 = value;
+            }
+        }
+    }
+
+    bounds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bspline_path_eval_segments() {
+        let knots: [f64; 4] = [0.0, 0.0, 1.0, 1.0];
+        let s1: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([0.0, 0.0]),
+                PointN::new([1.0, 0.0]),
+            ],
+        )
+        .unwrap();
+        let s2: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([1.0, 0.0]),
+                PointN::new([1.0, 1.0]),
+            ],
+        )
+        .unwrap();
+
+        let mut path: BSplinePath<PointN<f64, 2>, 4, 2, 1, 4> = BSplinePath::new();
+        path.push(s1);
+        path.push(s2);
+
+        let p1 = path.eval(0.25).unwrap();
+        assert!((p1 - PointN::new([0.5, 0.0])).squared_length() < EPSILON);
+
+        let p2 = path.eval(0.75).unwrap();
+        assert!((p2 - PointN::new([1.0, 0.5])).squared_length() < EPSILON);
+    }
+
+    #[test]
+    fn bspline_path_clamps_out_of_range() {
+        let knots: [f64; 4] = [0.0, 0.0, 1.0, 1.0];
+        let s1: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([0.0, 0.0]),
+                PointN::new([1.0, 0.0]),
+            ],
+        )
+        .unwrap();
+        let s2: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([1.0, 0.0]),
+                PointN::new([1.0, 1.0]),
+            ],
+        )
+        .unwrap();
+
+        let mut path: BSplinePath<PointN<f64, 2>, 4, 2, 1, 4> = BSplinePath::new();
+        path.push(s1);
+        path.push(s2);
+
+        let start = path.eval(-1.0).unwrap();
+        assert_eq!(start, PointN::new([0.0, 0.0]));
+
+        let end = path.eval(2.0).unwrap();
+        assert_eq!(end, PointN::new([1.0, 1.0]));
+    }
+
+    #[test]
+    fn bspline_path_bounds_control_points() {
+        let knots: [f64; 4] = [0.0, 0.0, 1.0, 1.0];
+        let s1: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([0.0, 2.0]),
+                PointN::new([1.0, -1.0]),
+            ],
+        )
+        .unwrap();
+        let s2: BSpline<PointN<f64, 2>, 4, 2, 1> = BSpline::new(
+            knots,
+            [
+                PointN::new([-1.0, 0.5]),
+                PointN::new([2.0, -2.0]),
+            ],
+        )
+        .unwrap();
+
+        let mut path: BSplinePath<PointN<f64, 2>, 4, 2, 1, 4> = BSplinePath::new();
+        path.push(s1);
+        path.push(s2);
+
+        let bounds = path.bounding_box().unwrap();
+        assert_eq!(bounds[0], (-1.0, 2.0));
+        assert_eq!(bounds[1], (-2.0, 2.0));
+    }
+}

--- a/src/find_root.rs
+++ b/src/find_root.rs
@@ -1,0 +1,63 @@
+use crate::point::Point;
+use crate::roots::RootFindingError;
+use crate::NativeFloat;
+use num_traits::Float;
+
+pub trait FindRoot<P: Point> {
+    /// Return the inclusive parameter domain for the curve.
+    fn parameter_domain(&self) -> (P::Scalar, P::Scalar);
+
+    /// Evaluate the curve along one axis.
+    fn axis_value(&self, t: P::Scalar, axis: usize) -> Result<P::Scalar, RootFindingError>;
+
+    /// Evaluate the curve's derivative along one axis.
+    fn axis_derivative(&self, t: P::Scalar, axis: usize) -> Result<P::Scalar, RootFindingError>;
+
+    /// Find a root for a particular axis using Newton-Raphson on the scalar axis function.
+    fn root_newton_axis(
+        &self,
+        value: P::Scalar,
+        axis: usize,
+        start: P::Scalar,
+        eps: Option<P::Scalar>,
+        max_iter: Option<usize>,
+    ) -> Result<P::Scalar, RootFindingError> {
+        let eps = eps.unwrap_or_else(|| P::Scalar::from(1e-6 as NativeFloat));
+        let max_iter = max_iter.unwrap_or(64);
+        let (kmin, kmax) = self.parameter_domain();
+
+        let clamp_t = |mut t: P::Scalar| {
+            if t < kmin {
+                t = kmin;
+            } else if t > kmax {
+                t = kmax;
+            }
+            t
+        };
+
+        let mut x = clamp_t(start);
+        for _ in 0..max_iter {
+            let t = clamp_t(x);
+            let fx = self.axis_value(t, axis)? - value;
+            if fx.abs() <= eps {
+                return Ok(t);
+            }
+
+            let dx = self.axis_derivative(t, axis)?;
+            if dx.abs() <= eps {
+                return Err(RootFindingError::ZeroDerivative);
+            }
+
+            let x1 = x - fx / dx;
+            if (x1 - x).abs() <= eps {
+                return Ok(clamp_t(x1));
+            }
+            if x1.is_nan() {
+                return Err(RootFindingError::FailedToConverge);
+            }
+            x = x1;
+        }
+
+        Err(RootFindingError::MaxIterationsReached)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod point;
 pub mod spline;
 pub mod path;
 pub mod bspline_path;
+pub mod find_root;
 
 mod roots;
 
@@ -49,6 +50,7 @@ pub use point::Point;
 pub use point_generic::PointN;
 pub use quadratic_bezier::QuadraticBezier;
 pub use bspline_path::BSplinePath;
+pub use find_root::FindRoot;
 pub use path::BezierPath;
 pub use spline::Spline;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,8 @@
 
 use core::ops::{Add, Mul, Sub};
 
-extern crate num_traits;
 use num_traits::float::Float;
 
-extern crate tinyvec;
 use tinyvec::ArrayVec;
 
 // abstraction types

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod point_generic;
 // Traits
 pub mod point;
 pub mod spline;
+pub mod path;
+pub mod bspline_path;
 
 mod roots;
 
@@ -46,6 +48,8 @@ pub use line::LineSegment;
 pub use point::Point;
 pub use point_generic::PointN;
 pub use quadratic_bezier::QuadraticBezier;
+pub use bspline_path::BSplinePath;
+pub use path::BezierPath;
 pub use spline::Spline;
 
 // Conditionally compiled newtype pattern used to determine which size float to use for internal constants

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,198 @@
+use core::slice;
+
+use crate::bezier_segment::BezierSegment;
+use super::*;
+
+/// A path composed of mixed Bezier segments (line/quadratic/cubic).
+pub struct BezierPath<P, const N: usize>
+where
+    P: Point,
+{
+    segments: ArrayVec<[BezierSegment<P>; N]>,
+}
+
+impl<P, const N: usize> BezierPath<P, N>
+where
+    P: Point,
+    [BezierSegment<P>; N]: tinyvec::Array<Item = BezierSegment<P>>,
+{
+    pub fn new() -> Self {
+        BezierPath {
+            segments: ArrayVec::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.segments.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.len() == 0
+    }
+
+    pub fn segments(&self) -> slice::Iter<'_, BezierSegment<P>> {
+        self.segments.iter()
+    }
+
+    pub fn push(&mut self, segment: BezierSegment<P>) -> bool {
+        if self.segments.len() < self.segments.capacity() {
+            self.segments.push(segment);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn push_line(&mut self, segment: LineSegment<P>) -> bool {
+        self.push(segment.into())
+    }
+
+    pub fn push_quadratic(&mut self, segment: QuadraticBezier<P>) -> bool {
+        self.push(segment.into())
+    }
+
+    pub fn push_cubic(&mut self, segment: CubicBezier<P>) -> bool {
+        self.push(segment.into())
+    }
+
+    /// Evaluate a point along the path for t in [0,1]. Returns None for empty paths.
+    pub fn eval(&self, t: P::Scalar) -> Option<P> {
+        let (index, local_t) = self.segment_parameter(t)?;
+        Some(self.segments[index].eval(local_t))
+    }
+
+    /// Return the bounding box across all segments. Returns None for empty paths.
+    pub fn bounding_box(&self) -> Option<[(P::Scalar, P::Scalar); P::DIM]> {
+        let mut iter = self.segments.iter();
+        let first = match iter.next() {
+            Some(segment) => segment.bounding_box(),
+            None => return None,
+        };
+
+        let mut bounds = first;
+        for segment in iter {
+            let segment_bounds = segment.bounding_box();
+            for dim in 0..P::DIM {
+                if segment_bounds[dim].0 < bounds[dim].0 {
+                    bounds[dim].0 = segment_bounds[dim].0;
+                }
+                if segment_bounds[dim].1 > bounds[dim].1 {
+                    bounds[dim].1 = segment_bounds[dim].1;
+                }
+            }
+        }
+
+        Some(bounds)
+    }
+
+    fn segment_parameter(&self, t: P::Scalar) -> Option<(usize, P::Scalar)> {
+        let count = self.segments.len();
+        if count == 0 {
+            return None;
+        }
+
+        let mut t_native: NativeFloat = t.into();
+        t_native = t_native.clamp(0.0, 1.0);
+
+        let count_native = count as NativeFloat;
+        let scaled = t_native * count_native;
+        if scaled >= count_native {
+            return Some((count - 1, P::Scalar::from(1.0)));
+        }
+
+        let index = scaled.floor() as usize;
+        let local = scaled - index as NativeFloat;
+        Some((index, P::Scalar::from(local)))
+    }
+}
+
+impl<P, const N: usize> Default for BezierPath<P, N>
+where
+    P: Point,
+    [BezierSegment<P>; N]: tinyvec::Array<Item = BezierSegment<P>>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bezier_path_eval_segments() {
+        let mut path: BezierPath<PointN<f64, 2>, 4> = BezierPath::new();
+        path.push_line(LineSegment::new(
+            PointN::new([0.0, 0.0]),
+            PointN::new([1.0, 0.0]),
+        ));
+        path.push_line(LineSegment::new(
+            PointN::new([1.0, 0.0]),
+            PointN::new([1.0, 1.0]),
+        ));
+
+        let p0 = path.eval(0.0).unwrap();
+        assert_eq!(p0, PointN::new([0.0, 0.0]));
+
+        let p1 = path.eval(0.25).unwrap();
+        assert!((p1 - PointN::new([0.5, 0.0])).squared_length() < EPSILON);
+
+        let p2 = path.eval(0.75).unwrap();
+        assert!((p2 - PointN::new([1.0, 0.5])).squared_length() < EPSILON);
+    }
+
+    #[test]
+    fn bezier_path_bounds_union() {
+        let mut path: BezierPath<PointN<f64, 2>, 4> = BezierPath::new();
+        path.push_line(LineSegment::new(
+            PointN::new([0.0, 0.0]),
+            PointN::new([1.0, 0.0]),
+        ));
+        path.push_line(LineSegment::new(
+            PointN::new([1.0, 0.0]),
+            PointN::new([1.0, 1.0]),
+        ));
+
+        let bounds = path.bounding_box().unwrap();
+        assert_eq!(bounds[0], (0.0, 1.0));
+        assert_eq!(bounds[1], (0.0, 1.0));
+    }
+
+    #[test]
+    fn bezier_path_clamps_out_of_range() {
+        let mut path: BezierPath<PointN<f64, 2>, 2> = BezierPath::new();
+        path.push_line(LineSegment::new(
+            PointN::new([0.0, 0.0]),
+            PointN::new([1.0, 0.0]),
+        ));
+        path.push_line(LineSegment::new(
+            PointN::new([1.0, 0.0]),
+            PointN::new([1.0, 1.0]),
+        ));
+
+        let start = path.eval(-1.0).unwrap();
+        assert_eq!(start, PointN::new([0.0, 0.0]));
+
+        let end = path.eval(2.0).unwrap();
+        assert_eq!(end, PointN::new([1.0, 1.0]));
+    }
+
+    #[test]
+    fn bezier_path_capacity() {
+        let mut path: BezierPath<PointN<f64, 2>, 1> = BezierPath::new();
+        let first = path.push_line(LineSegment::new(
+            PointN::new([0.0, 0.0]),
+            PointN::new([1.0, 0.0]),
+        ));
+        let second = path.push_line(LineSegment::new(
+            PointN::new([1.0, 0.0]),
+            PointN::new([2.0, 0.0]),
+        ));
+
+        assert!(first);
+        assert!(!second);
+        assert_eq!(path.len(), 1);
+    }
+
+}

--- a/src/point_generic.rs
+++ b/src/point_generic.rs
@@ -30,7 +30,7 @@ impl<T: Default + Copy, const N: usize> Default for PointN<T, N> {
 
 impl<T, const N: usize> PartialEq for PointN<T, N>
 where
-    T: PartialOrd,
+    T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
         for i in 0..N {
@@ -162,7 +162,7 @@ where
     const DIM: usize = { N };
 
     fn axis(&self, index: usize) -> Self::Scalar {
-        assert!(index <= N);
+        assert!(index < N);
         self.0[index].into()
     }
 

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -140,16 +140,16 @@ pub(crate) fn root_newton_raphson<F, Func, Deriv>(
 ) -> Result<F, RootFindingError>
 where
     F: Float,
-    Func: Fn(F) -> F,
-    Deriv: Fn(F) -> F,
+    Func: Fn(F) -> Result<F, RootFindingError>,
+    Deriv: Fn(F) -> Result<F, RootFindingError>,
 {
     let mut x = start;
     for _ in 0..max_iter {
-        let fx = f(x);
+        let fx = f(x)?;
         if fx.abs() <= eps {
             return Ok(x);
         }
-        let dx = d(x);
+        let dx = d(x)?;
         if dx.abs() <= eps {
             return Err(RootFindingError::ZeroDerivative);
         }


### PR DESCRIPTION
Add support for root finding of Bezier and BSpline curves over points of generic dimension (using newton-raphson).
Add BezierPath and BSplinePath for conveniently handling connected curve segments.
Increase test coverage and quality and fix some minor bugs.