### PR TITLE
Point API rework (breaking)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,3 +21,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests (nalgebra)
+      run: cargo test --features nalgebra --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,16 @@ exclude = [
 
 [dependencies]
 tinyvec = { version = "^1.8"} #{, features = ["rustc_1_55"] }
+nalgebra = { version = "^0.32", default-features = false, features = ["libm"], optional = true }
 
 
 [dependencies.num-traits]
 version = "^0.2"
 default-features = false
 features = ["libm"]    # use `Float` and `Real` without `std`
+
+[features]
+nalgebra = ["dep:nalgebra"]
 
 # these are just for development (e.g. integration tests and examples)
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,40 @@ A zero-allocation library providing const-generic implementations of Bézier cur
 
 The library makes heavy use of const-generics and `generic_const_exprs`, so the nightly compiler is required.  
 It comes with a const-generic N-dimensional Point type so you can use the library without any other dependencies.  
-`PointN` uses the platform's `NativeFloat` (f64 on 64-bit, f32 otherwise) for its scalar operations.  
-Should you want to integrate with types provided by another library, you are able to do so by implementing the small Point trait that the library relies upon (given it makes no distinction between a point and its position vector).  
+`PointN<T, N>` uses your chosen scalar `T` (typically `f32`/`f64`) and keeps the dimension at compile time.  
+Should you want to integrate with types provided by another library, implement the small `Point` trait. Optional extension traits (`PointIndex`, `PointDot`, `PointNorm`) unlock component access and geometric helpers when needed.  
+
+### Integration features
+
+- `nalgebra`: implements `Point` for `nalgebra::SVector<T, D>` (no_std + libm).
+  Requires `T: nalgebra::RealField + num_traits::Float` (typically `f32` or `f64`).
+
+Example:
+```rust
+use nalgebra::SVector;
+use stroke::Bezier;
+
+let curve = Bezier::<SVector<f32, 2>, 3>::new([
+    SVector::<f32, 2>::new(0.0, 0.0),
+    SVector::<f32, 2>::new(1.0, 0.0),
+    SVector::<f32, 2>::new(1.0, 1.0),
+]);
+
+let mid = curve.eval(0.5);
+```
+
+Enable with:
+```
+stroke = { version = "0.2.0", features = ["nalgebra"] }
+nalgebra = { version = "0.32", default-features = false, features = ["libm"] }
+```
+
+## Examples
+
+- `bezier_path`: mixed Bezier path segments; run `cargo run --example bezier_path`.
+- `bspline_path`: basic B-spline path evaluation; run `cargo run --example bspline_path`.
+- `plotters_cubic_bezier`: render a cubic Bezier with plotters; run `cargo run --example plotters_cubic_bezier`.
+- `nalgebra_basic`: Bezier with nalgebra SVector; run `cargo run --example nalgebra_basic --features nalgebra`.
 
 ![A Cubic Bézier Curve with Bounding Box and Convex Hull rendered by plotters.rs](https://raw.githubusercontent.com/dorianprill/stroke-rs/main/cubic_bezier_bounding_box.png)  
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These are the main supported features. Some further utility methods are exposed 
 - [x] arc length (linear approx.)
 - [ ] arc length (Legendre-Gauss)
 - [ ] curvature/radius (Frenet-Serret Frame)
-- [ ] bounding box
+- [x] bounding box
 - [ ] tight box
   
 ## Related  

--- a/examples/nalgebra_basic.rs
+++ b/examples/nalgebra_basic.rs
@@ -1,0 +1,20 @@
+#[cfg(feature = "nalgebra")]
+fn main() {
+    use nalgebra::SVector;
+    use stroke::Bezier;
+
+    let curve = Bezier::<SVector<f32, 2>, 3>::new([
+        SVector::<f32, 2>::new(0.0, 0.0),
+        SVector::<f32, 2>::new(1.0, 0.0),
+        SVector::<f32, 2>::new(1.0, 1.0),
+    ]);
+
+    let mid = curve.eval(0.5);
+    let bounds = curve.bounding_box();
+    println!("mid={:?}, bounds={:?}", mid, bounds);
+}
+
+#[cfg(not(feature = "nalgebra"))]
+fn main() {
+    eprintln!("Enable the nalgebra feature: cargo run --example nalgebra_basic --features nalgebra");
+}

--- a/examples/plotters_cubic_bezier.rs
+++ b/examples/plotters_cubic_bezier.rs
@@ -3,7 +3,6 @@ use plotters::prelude::*;
 
 extern crate stroke;
 use stroke::CubicBezier;
-use stroke::Point;
 use stroke::PointN;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -43,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     for t in 0..nsteps {
         let t = t as f64 * 1f64 / (nsteps as f64);
         let p = bezier.eval_casteljau(t);
-        bezier_graph.push((p.axis(0), p.axis(1)));
+        bezier_graph.push((p[0], p[1]));
     }
 
     let root = BitMapBackend::new("cubic_bezier_bounding_box.png", (640, 480)).into_drawing_area();

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,0 +1,7 @@
+//! Optional adapters for external math libraries.
+//!
+//! Enable feature flags (e.g. `nalgebra`) to add `Point` impls for
+//! external vector types.
+
+#[cfg(feature = "nalgebra")]
+pub mod nalgebra;

--- a/src/adapters/nalgebra.rs
+++ b/src/adapters/nalgebra.rs
@@ -1,0 +1,36 @@
+//! Nalgebra adapter implementations.
+//!
+//! Enable this adapter with the `nalgebra` feature to use `nalgebra::SVector<T, D>`
+//! as a `Point`. Add `nalgebra` as a direct dependency to construct the vectors
+//! in your own code.
+//!
+//! # Example
+//! ```rust,no_run
+//! use nalgebra::SVector;
+//! use stroke::Bezier;
+//!
+//! let curve = Bezier::<SVector<f32, 2>, 3>::new([
+//!     SVector::<f32, 2>::new(0.0, 0.0),
+//!     SVector::<f32, 2>::new(1.0, 0.0),
+//!     SVector::<f32, 2>::new(1.0, 1.0),
+//! ]);
+//!
+//! let mid = curve.eval(0.5);
+//! # let _ = mid;
+//! ```
+//!
+//! The scalar type must satisfy `nalgebra::RealField` and `num_traits::Float`
+//! (e.g. `f32` or `f64`).
+
+use nalgebra::{RealField, SVector};
+use num_traits::Float;
+
+use crate::point::Point;
+
+impl<T, const D: usize> Point for SVector<T, D>
+where
+    T: RealField + Float,
+{
+    type Scalar = T;
+    const DIM: usize = D;
+}

--- a/src/bspline.rs
+++ b/src/bspline.rs
@@ -1,17 +1,26 @@
+//! Const-generic B-spline curves.
+
 use core::slice::*;
 
-use super::point::Point;
-use super::*;
+use num_traits::{Float, NumCast};
+use super::{Point, PointIndex, PointNorm};
 use crate::find_root::FindRoot;
 use crate::roots::{root_newton_raphson, RootFindingError};
 
+/// Errors returned by B-spline construction or evaluation.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BSplineError {
+    /// The curve has fewer control points than required by its degree.
     TooFewControlPoints,
+    /// The knot vector has fewer entries than required by the degree and control points.
     TooFewKnots,
+    /// The knot vector has more entries than required by the degree and control points.
     TooManyKnots,
+    /// The knot vector is not non-decreasing.
     DecreasingKnots,
+    /// The evaluation parameter is outside the knot domain.
     KnotDomainViolation,
+    /// The de Boor evaluation encountered a NaN alpha value.
     EvaluationAlphaIsNaN,
 }
 
@@ -44,17 +53,15 @@ impl core::fmt::Display for BSplineError {
     }
 }
 
-/// General Implementation of a BSpline with choosable degree, control points and knots.
+/// Const-generic B-spline curve with fixed control-point and knot counts.
 ///
-/// Generic parameters:
-/// P: const generic points array 'P' as defined by the Point trait
-/// F: Any float value used for the knots and interpolation (usually the same as the internal generic parameter within P<F>).
-/// const generic parameters:
-/// C: Number of control points
-/// K: Number of Knots
-/// D: Degree of the piecewise function used for interpolation degree = order - 1
-/// While C, K, D relate to each other in the following manner
-///     K = C + D + 1
+/// The scalar type used for the knots and interpolation is `P::Scalar`.
+///
+/// # Parameters
+/// - `P`: point type implementing [`Point`](crate::point::Point).
+/// - `C`: number of control points.
+/// - `K`: number of knots (`K = C + D + 1`).
+/// - `D`: degree (order - 1).
 #[derive(Clone, Copy)]
 pub struct BSpline<P, const K: usize, const C: usize, const D: usize>
 where
@@ -70,7 +77,8 @@ where
 
 impl<P, const K: usize, const C: usize, const D: usize> Default for BSpline<P, K, C, D>
 where
-    P: Point,
+    P: Point + Default,
+    P::Scalar: Default,
 {
     fn default() -> Self {
         BSpline {
@@ -211,7 +219,7 @@ where
     // {
     //     let nsteps: usize = 64;
     //     let mut tmin: P::Scalar = 0.5.into();
-    //     let mut dmin: P::Scalar = (point - self.control_points[0]).squared_length();
+    //     let mut dmin: P::Scalar = (point - self.control_points[0]).squared_norm();
     //     let (kstart, kend) = self.knot_domain();
     //     // 1. coarse pass
     //     for i in 0..nsteps {
@@ -224,12 +232,12 @@ where
     //             Err(_) => {
     //                 // In case of error, return zero
     //                 // this can never happen as we control the t values passed to eval()
-    //                 return P::Scalar::from(0.0);
+    //                 return <P::Scalar as NumCast>::from(0.0);
     //             }
     //         };
-    //         if (candidate - point).squared_length() < dmin {
+    //         if (candidate - point).squared_norm() < dmin {
     //             tmin = t;
-    //             dmin = (candidate - point).squared_length();
+    //             dmin = (candidate - point).squared_norm();
     //         }
     //     }
     //     // 2. fine pass
@@ -243,12 +251,12 @@ where
     //             Err(_) => {
     //                 // In case of error, return zero
     //                 // this can never happen as we control the t values passed to eval()
-    //                 return P::Scalar::from(0.0);
+    //                 return <P::Scalar as NumCast>::from(0.0);
     //             }
     //         };
-    //         if (candidate - point).squared_length() < dmin {
+    //         if (candidate - point).squared_norm() < dmin {
     //             tmin = t;
-    //             dmin = (candidate - point).squared_length();
+    //             dmin = (candidate - point).squared_norm();
     //         }
     //     }
     //     dmin.sqrt()
@@ -276,7 +284,7 @@ where
         };
 
         // Create a second array for storing intermediate results
-        let mut d: [P; D + 1] = [P::default(); D + 1];
+        let mut d: [P; D + 1] = core::array::from_fn(|_| self.control_points[0]);
 
         // Copy the control points needed for the first iteration
         // For a B-Spline of degree D, D+1 control points in the knot span contribute to the result
@@ -302,14 +310,16 @@ where
                 // calculate alpha, avoid division by zero
                 let numerator = t - self.knots[j + k - D];
                 let denominator = self.knots[j + 1 + k - r] - self.knots[j + k - D];
+                let zero = <P::Scalar as NumCast>::from(0.0).unwrap();
+                let one = <P::Scalar as NumCast>::from(1.0).unwrap();
                 let alpha: P::Scalar;
                 if numerator < P::Scalar::epsilon() {
                     // we are at the start of a knot span (interpolation d[j-1] -> d[j])
-                    alpha = 0.0.into();
+                    alpha = zero;
                 } else if denominator.abs() < P::Scalar::epsilon() {
                     // we are at then end of a knot span (interpolation d[j-1] -> d[j])
                     // this will lead to d[j] simply being copied to d[j]
-                    alpha = 1.0.into();
+                    alpha = one;
                 } else {
                     // inside a knot span (interpolation d[j-1] -> d[j])
                     alpha = numerator / denominator;
@@ -319,7 +329,7 @@ where
                 }
                 // The right of two points is overwritten by the result
                 // to be used in the next iteration
-                d[j] = d[j - 1] * (1.0 - alpha.into()) + d[j] * alpha;
+                d[j] = d[j - 1] * (one - alpha) + d[j] * alpha;
             }
         }
         Ok(d[D])
@@ -459,26 +469,27 @@ where
     /// This approximation is unfeasable if desired accuracy is greater than ~2 decimal places
     pub fn arclen(&self, nsteps: usize) -> P::Scalar
     where
+        P: PointNorm,
         [(); D + 1]: Sized,
     {
-        let stepsize = P::Scalar::from(1.0 / (nsteps as NativeFloat));
-        let mut arclen: P::Scalar = 0.0.into();
+        let nsteps_scalar = <P::Scalar as NumCast>::from(nsteps as f64).unwrap();
+        let stepsize = <P::Scalar as NumCast>::from(1.0).unwrap() / nsteps_scalar;
+        let mut arclen: P::Scalar = <P::Scalar as NumCast>::from(0.0).unwrap();
         // evaluate the curve, t needs to be inside the knot domain!
         // we need to map [0...1] to kmin..kmax
         let (kmin, kmax) = self.knot_domain();
         for t in 0..=nsteps {
             let t = kmin
-                + (P::Scalar::from(t as NativeFloat) / P::Scalar::from(nsteps as NativeFloat))
-                    * (kmax - kmin);
+                + (<P::Scalar as NumCast>::from(t as f64).unwrap() / nsteps_scalar) * (kmax - kmin);
             let p1 = self.eval(t).unwrap_or_else(|_| {
                 // should never happen as we control the t values passed to eval()
-                P::default()
+                self.control_points[0]
             });
             let p2 = self.eval(t + stepsize).unwrap_or_else(|_| {
                 // should never happen as we control the t values passed to eval()
-                P::default()
+                self.control_points[0]
             });
-            arclen = arclen + (p1 - p2).squared_length().sqrt();
+            arclen = arclen + (p1 - p2).squared_norm().sqrt();
         }
         arclen
     }
@@ -500,8 +511,9 @@ where
         let derivative_knots: [P::Scalar; K - 2] =
             core::array::from_fn(|i| self.knots[i + 1]);
         let derivative_points: [P; C - 1] = core::array::from_fn(|i| {
-            (self.control_points[i + 1] - self.control_points[i])
-                * ((D) as NativeFloat / (self.knots[i + D + 1] - self.knots[i + 1]).into())
+            let scale = <P::Scalar as NumCast>::from(D as f64).unwrap()
+                / (self.knots[i + D + 1] - self.knots[i + 1]);
+            (self.control_points[i + 1] - self.control_points[i]) * scale
         });
 
         let degree = D - 1;
@@ -553,6 +565,7 @@ where
         [(); C - 1]: Sized,
         [(); (D - 1) + 1]: Sized,
         [(); K - 2]: Sized,
+        P: PointIndex,
     {
         FindRoot::root_newton_axis(self, value, axis, start, eps, max_iter)
     }
@@ -560,7 +573,7 @@ where
 
 impl<P, const K: usize, const C: usize, const D: usize> FindRoot<P> for BSpline<P, K, C, D>
 where
-    P: Point,
+    P: PointIndex,
     [(); D + 1]: Sized,
     [(); D - 1]: Sized,
     [(); D]: Sized,
@@ -574,7 +587,7 @@ where
 
     fn axis_value(&self, t: P::Scalar, axis: usize) -> Result<P::Scalar, RootFindingError> {
         self.eval(t)
-            .map(|p| p.axis(axis))
+            .map(|p| p[axis])
             .map_err(|_| RootFindingError::FailedToConverge)
     }
 
@@ -582,7 +595,7 @@ where
         let derivative = self.derivative_curve()?;
         derivative
             .eval(t)
-            .map(|p| p.axis(axis))
+            .map(|p| p[axis])
             .map_err(|_| RootFindingError::FailedToConverge)
     }
 
@@ -594,7 +607,7 @@ where
         eps: Option<P::Scalar>,
         max_iter: Option<usize>,
     ) -> Result<P::Scalar, RootFindingError> {
-        let eps = eps.unwrap_or_else(|| P::Scalar::from(1e-6 as NativeFloat));
+        let eps = eps.unwrap_or_else(|| <P::Scalar as NumCast>::from(1e-6).unwrap());
         let max_iter = max_iter.unwrap_or(64);
         let (kmin, kmax) = self.knot_domain();
         let derivative = self.derivative_curve()?;
@@ -617,7 +630,7 @@ where
             let t = clamp_t(x);
             derivative
                 .eval(t)
-                .map(|p| p.axis(axis))
+                .map(|p| p[axis])
                 .map_err(|_| RootFindingError::FailedToConverge)
         };
 
@@ -629,9 +642,9 @@ where
 #[cfg(test)]
 mod tests {
     //use std;
-    use super::PointN;
     use super::*;
     //use crate::num_traits::{Pow};
+    use crate::{PointN, EPSILON};
 
     #[test]
     fn degree_1_clamped_construct_and_eval_endpoints() {
@@ -707,7 +720,7 @@ mod tests {
 
         // Check that the start and end points have equal distance to the midpoint of the line
         assert!(
-            (points[1] - mid).squared_length().sqrt() - (points[0] - mid).squared_length().sqrt()
+            (points[1] - mid).squared_norm().sqrt() - (points[0] - mid).squared_norm().sqrt()
                 < EPSILON
         );
     }
@@ -788,7 +801,7 @@ mod tests {
 
         // Check that the start and end points have equal distance to the midpoint of the line
         assert!(
-            (points[1] - mid).squared_length().sqrt() - (points[0] - mid).squared_length().sqrt()
+            (points[1] - mid).squared_norm().sqrt() - (points[0] - mid).squared_norm().sqrt()
                 < EPSILON
         );
     }

--- a/src/find_root.rs
+++ b/src/find_root.rs
@@ -1,8 +1,11 @@
-use crate::point::Point;
-use crate::roots::{root_newton_raphson, RootFindingError};
-use crate::NativeFloat;
+//! Root-finding helpers for curve types that support per-axis evaluation.
 
-pub trait FindRoot<P: Point> {
+use num_traits::NumCast;
+use crate::point::PointIndex;
+use crate::roots::{root_newton_raphson, RootFindingError};
+
+/// Helper trait for 1D root finding along a curve axis.
+pub trait FindRoot<P: PointIndex> {
     /// Return the inclusive parameter domain for the curve.
     fn parameter_domain(&self) -> (P::Scalar, P::Scalar);
 
@@ -21,7 +24,7 @@ pub trait FindRoot<P: Point> {
         eps: Option<P::Scalar>,
         max_iter: Option<usize>,
     ) -> Result<P::Scalar, RootFindingError> {
-        let eps = eps.unwrap_or_else(|| P::Scalar::from(1e-6 as NativeFloat));
+        let eps = eps.unwrap_or_else(|| <P::Scalar as NumCast>::from(1e-6).unwrap());
         let max_iter = max_iter.unwrap_or(64);
         let (kmin, kmax) = self.parameter_domain();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub mod find_root;
 
 mod roots;
 
+#[cfg(feature = "nalgebra")]
+mod adapters;
+
 // export common types at crate root
 pub use bezier::Bezier;
 pub use bspline::BSpline;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,31 @@
 // this is needed to use expressions in const generics such as N-1 (see curve derivatives)
 #![feature(generic_const_exprs)]
 
+//! A const-generic, no-std spline library for Bezier and B-spline curves.
+//!
+//! The core abstraction is the [`Point`](crate::point::Point) trait, which models
+//! a fixed-dimension vector space element. Optional capability traits such as
+//! [`PointIndex`](crate::point::PointIndex), [`PointDot`](crate::point::PointDot),
+//! and [`PointNorm`](crate::point::PointNorm) enable component access and
+//! geometric helpers when required.
+//!
+//! # Examples
+//! ```rust
+//! use stroke::{Bezier, PointN};
+//!
+//! let curve = Bezier::<PointN<f32, 2>, 3>::new([
+//!     PointN::new([0.0, 0.0]),
+//!     PointN::new([1.0, 0.0]),
+//!     PointN::new([1.0, 1.0]),
+//! ]);
+//!
+//! let mid = curve.eval(0.5);
+//! # let _ = mid;
+//! ```
+//!
+//! # Feature flags
+//! - `nalgebra`: implements `Point` for `nalgebra::SVector<T, D>` (add `nalgebra` as a dependency).
+
 // this feature was needed for tinyvec < 2.0 to compile for const generic arrays like ArrayVec<[f32;N]>
 //#![feature(min_const_generics)]
 
@@ -14,10 +39,6 @@
 
 // make splines usable as Fn in trait bounds
 //#![feature(fn_traits)]
-
-use core::ops::{Add, Mul, Sub};
-
-use num_traits::float::Float;
 
 use tinyvec::ArrayVec;
 
@@ -47,6 +68,7 @@ pub use bspline::BSpline;
 pub use cubic_bezier::CubicBezier;
 pub use line::LineSegment;
 pub use point::Point;
+pub use point::{PointDot, PointIndex, PointNorm};
 pub use point_generic::PointN;
 pub use quadratic_bezier::QuadraticBezier;
 pub use bspline_path::BSplinePath;

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,10 +1,15 @@
-use super::Point;
-use super::*;
+//! Line segment curve type.
 
-/// LineSegment defined by a start and an endpoint, evaluable anywhere inbetween using interpolation parameter t: [0,1] in eval()
+use num_traits::{Float, NumCast};
+use super::{ArrayVec, Point, PointDot, PointIndex, PointNorm};
+
+/// LineSegment defined by a start and an endpoint, evaluable anywhere inbetween using interpolation parameter t: [0,1] in eval().
 ///
 /// A LineSegment is equal to a linear Bezier curve, which is why there is no
 /// specialized type for that case.
+///
+/// Methods that need component access or norms add `PointIndex`/`PointNorm`
+/// bounds as required.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct LineSegment<P> {
     pub(crate) start: P,
@@ -15,14 +20,17 @@ impl<P> LineSegment<P>
 where
     P: Point,
 {
+    /// Create a new line segment from `start` to `end`.
     pub fn new(start: P, end: P) -> Self {
         LineSegment { start, end }
     }
 
+    /// Evaluate a point along the segment for `t` in `[0, 1]`.
     pub fn eval(&self, t: P::Scalar) -> P {
         self.start + (self.end - self.start) * t
     }
 
+    /// Split the segment at `t` into two sub-segments.
     pub fn split(&self, t: P::Scalar) -> (Self, Self) {
         // compute the split point by interpolation
         let ctrl_ab = self.start + (self.end - self.start) * t;
@@ -48,44 +56,44 @@ where
     // }
 
     /// Return the distance from the LineSegment to Point p by calculating the projection
-    pub fn distance_to_point(&self, p: P) -> P::Scalar {
-        let l2 = (self.end - self.start).squared_length();
+    pub fn distance_to_point(&self, p: P) -> P::Scalar
+    where
+        P: PointNorm,
+    {
+        let l2 = (self.end - self.start).squared_norm();
         // if start and endpoint are approx the same, return the distance to either
-        if l2 < P::Scalar::from(EPSILON) {
-            (self.start - p).squared_length().sqrt()
+        if l2 < P::Scalar::epsilon() {
+            (self.start - p).squared_norm().sqrt()
         } else {
             let v1 = p - self.start;
             let v2 = self.end - self.start;
-            let mut dot = P::Scalar::from(0.0);
-            for (i, _) in v1.into_iter().enumerate() {
-                dot = dot + v1.axis(i) * v2.axis(i);
-            }
+            let dot = PointDot::dot(&v1, &v2);
             // v1 and v2 will by definition always have the same number of axes and produce a value for each Item
             // dot = v1.into_iter()
             //         .zip(v2.into_iter())
             //         .map(|(x1, x2)| x1 * x2)
             //         .sum::<P::Scalar>();
-            let t = (dot / l2).clamp(P::Scalar::from(0.0), P::Scalar::from(1.0));
+            let t = (dot / l2).clamp(
+                <P::Scalar as NumCast>::from(0.0).unwrap(),
+                <P::Scalar as NumCast>::from(1.0).unwrap(),
+            );
             let projection = self.start + (self.end - self.start) * t; // Projection falls on the segment
 
-            (p - projection).squared_length().sqrt()
+            (p - projection).squared_norm().sqrt()
         }
     }
 
-    /// Sample the coordinate axis of the segment at t (expecting t between 0 and 1).
-    pub fn axis(&self, t: P::Scalar, axis: usize) -> P::Scalar {
-        self.start.axis(axis) + (self.end.axis(axis) - self.start.axis(axis)) * t
-    }
-
-    /// Return the derivative function.
-    /// The derivative is also a bezier curve but of degree n-1 - In the case of a line the derivative vector.
+    /// Return the derivative vector of the segment.
     pub fn derivative(&self) -> P {
         self.end - self.start
     }
 
-    pub(crate) fn root(&self, a: P::Scalar, b: P::Scalar) -> ArrayVec<[P::Scalar; 1]> {
+    pub(crate) fn root(&self, a: P::Scalar, b: P::Scalar) -> ArrayVec<[P::Scalar; 1]>
+    where
+        [P::Scalar; 1]: tinyvec::Array<Item = P::Scalar>,
+    {
         let mut r = ArrayVec::new();
-        if a.abs() < EPSILON.into() {
+        if a.abs() < P::Scalar::epsilon() {
             return r;
         }
         r.push(-b / a);
@@ -93,16 +101,18 @@ where
     }
 
     /// Return the bounding box of the line as an array of (min, max) tuples for each dimension (its index)
-    pub fn bounding_box(&self) -> [(P::Scalar, P::Scalar); P::DIM] {
-        let mut bounds = [(P::Scalar::default(), P::Scalar::default()); P::DIM];
+    pub fn bounding_box(&self) -> [(P::Scalar, P::Scalar); P::DIM]
+    where
+        P: PointIndex,
+    {
+        let mut bounds = [(<P::Scalar as NumCast>::from(0.0).unwrap(), <P::Scalar as NumCast>::from(0.0).unwrap()); P::DIM];
 
-        // find min/max for that particular axis
-        // TODO shoul be rewritten once 'Iterator' is implemented on P to get rid of .axis() method
-        for (i, _) in self.start.into_iter().enumerate() {
-            if self.start.axis(i) < self.end.axis(i) {
-                bounds[i] = (self.start.axis(i), self.end.axis(i));
+        // find min/max for each axis
+        for i in 0..P::DIM {
+            if self.start[i] < self.end[i] {
+                bounds[i] = (self.start[i], self.end[i]);
             } else {
-                bounds[i] = (self.end.axis(i), self.start.axis(i));
+                bounds[i] = (self.end[i], self.start[i]);
             }
         }
 
@@ -112,7 +122,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::point_generic::PointN;
+    use crate::{PointN, EPSILON};
     use super::*;
     /// Check whether a line segment interpolation p + t*(q-p) at t=0.5
     /// yields equal distance to the start (p)/end (q) points (up to machine accuracy).
@@ -124,7 +134,7 @@ mod tests {
         };
 
         let mid = line.eval(0.5);
-        assert!((mid - line.start).squared_length() - (mid - line.end).squared_length() < EPSILON)
+        assert!((mid - line.start).squared_norm() - (mid - line.end).squared_norm() < EPSILON)
     }
 
     /// Check whether classic pythagorean equality holds for sides 3, 4 with hypothenuse 5
@@ -138,11 +148,11 @@ mod tests {
         // dist to start should be 4; dist to end should be 5
         let p1 = PointN::new([0f64, 5f64, 0f64]);
         assert!(line.distance_to_point(p1) - 4.0.abs() < EPSILON);
-        assert!(((p1 - line.start).squared_length().sqrt() - 4.0).abs() < EPSILON);
-        assert!(((p1 - line.end).squared_length().sqrt() - 5.0).abs() < EPSILON);
+        assert!(((p1 - line.start).squared_norm().sqrt() - 4.0).abs() < EPSILON);
+        assert!(((p1 - line.end).squared_norm().sqrt() - 5.0).abs() < EPSILON);
         // dist to midpoint (t=0.5) should be 1
         let p2 = PointN::new([1.5f64, 2f64, 0f64]);
-        assert!(((p2 - line.eval(0.5)).squared_length().sqrt() - 1.0).abs() < EPSILON);
+        assert!(((p2 - line.eval(0.5)).squared_norm().sqrt() - 1.0).abs() < EPSILON);
     }
 
     #[test]

--- a/src/roots.rs
+++ b/src/roots.rs
@@ -1,11 +1,14 @@
-/// roots.rs
-/// const-generic functions to find polynomial roots using tinyvec::ArrayVec
-/// available functions:
-///   roots_square()
-///   roots_cubic()
-///   roots_newton() WIP
-/// there will probably be no function for quartics, since specialized beziers only go up to cubic
-use super::*;
+//! Polynomial root helpers using `tinyvec::ArrayVec`.
+//!
+//! Available functions:
+//! - `roots_square()`
+//! - `roots_cubic()`
+//! - `root_newton_raphson()`
+//!
+//! There will probably be no function for quartics, since specialized
+//! Beziers only go up to cubic.
+use num_traits::Float;
+use super::{ArrayVec, EPSILON, NativeFloat};
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/spline.rs
+++ b/src/spline.rs
@@ -1,7 +1,8 @@
-/// spline.rs
-/// Trait for common abstractions over all spline types (Bezier, B-Spline)
+//! Common spline abstraction for evaluatable curve types.
 use super::Point;
 
+/// Trait implemented by spline types that can be evaluated at a parameter `t`.
 pub trait Spline<P: Point> {
+    /// Evaluate the spline at parameter `t`.
     fn eval(&self, t: P::Scalar) -> P;
 }


### PR DESCRIPTION
Reworked the Point trait API into minimal core + capability traits to improve interop and avoid leaking internal numeric policy.
Added nalgebra support (feature‑gated adapter + example + CI coverage).
Implemented exact BSpline bounding boxes via per‑axis extrema search and updated docs/examples accordingly.
