### PR TITLE
Add generic curve examples

### DIFF
--- a/examples/arc_length_sampling.rs
+++ b/examples/arc_length_sampling.rs
@@ -1,0 +1,28 @@
+use stroke::{Bezier, PointN, PointNorm};
+
+fn main() {
+    let curve = Bezier::<PointN<f64, 2>, 4>::new([
+        PointN::new([0.0, 0.0]),
+        PointN::new([1.0, 2.0]),
+        PointN::new([3.0, -1.0]),
+        PointN::new([4.0, 0.0]),
+    ]);
+
+    let steps = 6;
+    let nsteps = 512;
+    let total = curve.arclen(nsteps);
+    println!("total length (approx): {:.5}", total);
+
+    let mut prev: Option<PointN<f64, 2>> = None;
+    for i in 0..steps {
+        let s = total * (i as f64 / (steps - 1) as f64);
+        let t = curve.t_at_length_approx(s, nsteps);
+        let p = curve.point_at_length_approx(s, nsteps);
+        let gap = prev.map(|q| (p - q).squared_norm().sqrt());
+        match gap {
+            Some(d) => println!("i={}  s={:.4}  t={:.4}  p={:?}  gap={:.4}", i, s, t, p, d),
+            None => println!("i={}  s={:.4}  t={:.4}  p={:?}", i, s, t, p),
+        }
+        prev = Some(p);
+    }
+}

--- a/examples/bezier_quarter_circle.rs
+++ b/examples/bezier_quarter_circle.rs
@@ -1,0 +1,31 @@
+use stroke::{Bezier, PointN};
+
+fn main() {
+    // Classic cubic Bezier approximation of a quarter circle.
+    let kappa = 4.0 / 3.0 * (2.0_f64.sqrt() - 1.0);
+    let curve = Bezier::<PointN<f64, 2>, 4>::new([
+        PointN::new([1.0, 0.0]),
+        PointN::new([1.0, kappa]),
+        PointN::new([kappa, 1.0]),
+        PointN::new([0.0, 1.0]),
+    ]);
+
+    let samples = 100;
+    let mut max_err = 0.0;
+    for i in 0..=samples {
+        let t = i as f64 / samples as f64;
+        let p = curve.eval(t);
+        let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+        let err = (r - 1.0).abs();
+        if err > max_err {
+            max_err = err;
+        }
+    }
+
+    println!("kappa={:.9}", kappa);
+    println!(
+        "max radial error over {} samples: {:.6e}",
+        samples + 1,
+        max_err
+    );
+}

--- a/examples/tangent_normal_curvature.rs
+++ b/examples/tangent_normal_curvature.rs
@@ -1,0 +1,55 @@
+use stroke::{Bezier, PointN};
+
+fn main() {
+    let curve = Bezier::<PointN<f64, 2>, 4>::new([
+        PointN::new([-1.0, 0.0]),
+        PointN::new([-0.5, 1.5]),
+        PointN::new([0.5, -1.5]),
+        PointN::new([1.0, 0.0]),
+    ]);
+
+    println!("t    p(x,y)         tan(x,y)       kappa   normal sketch");
+    let samples = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
+    for t in samples {
+        let p = curve.eval(t);
+        let tan = curve.tangent(t);
+        let kappa = curve.curvature(t);
+        let arrow = match curve.normal(t) {
+            Some(n) => arrow_from_vec(n[0], n[1]),
+            None => '?',
+        };
+        let sketch = hedgehog_line(p[0], arrow);
+        println!(
+            "{:>3.1}  ({:>6.3},{:>6.3})  ({:>6.3},{:>6.3})  {:>6.3}  {}",
+            t, p[0], p[1], tan[0], tan[1], kappa, sketch
+        );
+    }
+}
+
+fn arrow_from_vec(x: f64, y: f64) -> char {
+    if x.abs() >= y.abs() {
+        if x >= 0.0 {
+            '>'
+        } else {
+            '<'
+        }
+    } else if y >= 0.0 {
+        '^'
+    } else {
+        'v'
+    }
+}
+
+fn hedgehog_line(x: f64, arrow: char) -> String {
+    let width = 24usize;
+    let mut line = vec!['.'; width];
+    let mut pos = ((x + 1.0) * 0.5 * (width as f64 - 1.0)).round() as isize;
+    if pos < 0 {
+        pos = 0;
+    }
+    if pos >= width as isize {
+        pos = width as isize - 1;
+    }
+    line[pos as usize] = arrow;
+    line.into_iter().collect()
+}

--- a/examples/tangent_normal_curvature.rs
+++ b/examples/tangent_normal_curvature.rs
@@ -28,11 +28,7 @@ fn main() {
 
 fn arrow_from_vec(x: f64, y: f64) -> char {
     if x.abs() >= y.abs() {
-        if x >= 0.0 {
-            '>'
-        } else {
-            '<'
-        }
+        if x >= 0.0 { '>' } else { '<' }
     } else if y >= 0.0 {
         '^'
     } else {

--- a/src/bezier.rs
+++ b/src/bezier.rs
@@ -284,6 +284,7 @@ where
         let first = self.derivative();
         let v = first.eval(t);
         let a = if N < 3 {
+            // N < 3 has no second derivative; use a typed zero vector.
             v - v
         } else {
             first.derivative().eval(t)
@@ -323,6 +324,7 @@ where
             return None;
         }
         let a = if N < 3 {
+            // N < 3 has no second derivative; use a typed zero vector.
             v - v
         } else {
             first.derivative().eval(t)


### PR DESCRIPTION
- add generic Bezier examples for quarter-circle approximation, arc-length sampling, and tangent/normal/curvature
- use const-generic Bezier types in examples to match the core API
- include arc-length sampling with increased step count for smoother spacing