### PR TITLE
Prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.3.0] - 2026-01-22
+
+### Breaking changes
+- Refactored Point trait bounds and curve trait requirements; downstream implementations may need updates.
+- Removed the old Spline trait.
+- BSpline arc length and distance helpers are now fallible and return Result when evaluation can fail outside the knot domain.
+
+### Added
+- Generic Bezier and BSpline root finding via the FindRoot helper.
+- BSpline basis functions (with derivatives) and bounding box support.
+- BezierPath and BSplinePath types for multi-segment paths.
+- nalgebra feature adapter for SVector integration.
+- New examples: B-spline 1D interpolation, generic Bezier quarter-circle, arc-length sampling, and tangent/normal/curvature sampling.
+
+### Changed
+- Upgraded to Rust 2024 edition and pinned a nightly toolchain for const-generic features.
+- Improved arc-length and distance approximation routines across curve types.
+- Plotters example renamed/excluded from tests; example documentation expanded.
+
+### Fixed
+- Corrected De Casteljau and line math edge cases.
+- Fixed B-spline derivative edge cases, knot span search, and out-of-bounds handling.
+- Addressed clippy lint warnings and rustdoc issues; expanded CI coverage.
+
+## [0.2.0] - 2024-09-27
+
+### Breaking changes
+- Major API rework of Point trait bounds and curve generics.
+- BSpline const generic switched from "order" to "degree" and related type parameters updated.
+- Removed unfinished RationalBezier type.
+- Added BSplineError / KnotVectorKind, changing BSpline construction and validation behavior.
+
+### Added
+- distance_to_point helpers for Bezier, BSpline, QuadraticBezier, and CubicBezier.
+- Bezier arc length approximation.
+- BSpline derivative support.
+- Root solver module groundwork (root_newton_raphson).
+- Control point iterators for Bezier types.
+
+### Changed
+- Updated to Rust 2021 edition and refreshed documentation/readme.
+- Enabled tinyvec const-generic support to improve PointN usability.
+
+### Fixed
+- Corrected generic Bezier derivative implementation.
+- Resolved BSpline distance_to_point test failures and related edge cases.
+- Addressed clippy warnings and architecture-specific constants.
+
+See: https://github.com/dorianprill/stroke/releases/tag/v0.2.0
+
+## [0.1.0] - 2022-02-24
+
+### Added
+- Initial no_std release with const-generic PointN and Point trait.
+- Specialized line, quadratic, and cubic Bezier types with eval, split, derivative, arc length, and bounding box helpers.
+- Generic Bezier and BSpline types with eval, split, derivative, and arc length support.
+- Plotters-based example image and basic documentation.
+
+See: https://github.com/dorianprill/stroke/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,39 +1,38 @@
 [package]
 name = "stroke"
-version = "0.2.0"
-description = """A zero-allocation library providing const-generic 
-                implementations of Bézier curves, B-Spline curves 
-                and specialized implementations of up to cubic Bézier 
-                curves in N-dimensional euclidean space. It is intended 
-                for general/embedded/wasm use supporting #![no_std] 
-                environments written in 100% safe Rust."""
+version = "0.3.0"
+description = """Zero-allocation, const-generic implementations of Bézier and B-Spline curves in N-dimensional euclidean space."""
 authors = ["Dorian Prill"]
 repository = "https://github.com/dorianprill/stroke"
 readme = "README.md"
-keywords = ["point", "bezier", "spline", "graphics", "path" ]
-categories = ["no-std", "science", "graphics", "mathematics", "data-structures" ]
+keywords = ["point", "bezier", "spline", "graphics", "path"]
+categories = ["no-std", "science", "graphics", "mathematics", "data-structures"]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.95"
 license = "MIT"
 
 
-exclude = [
-    "*.png",
-    "examples/*",
-    ".github/*",
-    ".gitignore",
-    ".vscode/*",
+include = [
+    "Cargo.toml",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE",
+    "rust-toolchain",
+    "src/**",
+    "examples/**/*.rs",
 ]
 
 [dependencies]
-tinyvec = { version = "^1.8"} #{, features = ["rustc_1_55"] }
-nalgebra = { version = "^0.32", default-features = false, features = ["libm"], optional = true }
+tinyvec = { version = "^1.10.0" } #{, features = ["rustc_1_55"] }
+nalgebra = { version = "^0.34.1", default-features = false, features = [
+    "libm",
+], optional = true }
 
 
 [dependencies.num-traits]
 version = "^0.2"
 default-features = false
-features = ["libm"]    # use `Float` and `Real` without `std`
+features = ["libm"]      # use `Float` and `Real` without `std`
 
 [features]
 nalgebra = ["dep:nalgebra"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ made with [plotters.rs](https://github.com/38/plotters)
 A zero-allocation library providing const-generic implementations of Bézier curves, B-Spline curves and specialized implementations of up to cubic Bézier curves in N-dimensional euclidean space. It is intended for general/embedded/wasm use supporting #![no_std] environments written in 100% safe Rust with minimal dependencies.  
 
 The library makes heavy use of const-generics and `generic_const_exprs`, so the nightly compiler is required.  
+This repo uses `nightly` via `rust-toolchain`.  
 It comes with a const-generic N-dimensional Point type so you can use the library without any other dependencies.  
 `PointN<T, N>` uses your chosen scalar `T` (typically `f32`/`f64`) and keeps the dimension at compile time.  
 Should you want to integrate with types provided by another library, implement the small `Point` trait. Optional extension traits (`PointIndex`, `PointDot`, `PointNorm`) unlock component access and geometric helpers when needed.  
@@ -39,7 +40,7 @@ let mid = curve.eval(0.5);
 Enable with:
 
 ```toml
-stroke = { version = "0.2.0", features = ["nalgebra"] }
+stroke = { version = "0.3.0", features = ["nalgebra"] }
 nalgebra = { version = "0.32", default-features = false, features = ["libm"] }
 ```
 
@@ -111,6 +112,9 @@ These are the main supported features. Some further utility methods are exposed 
 - `bezier_path`: mixed Bezier path segments; run `cargo run --example bezier_path`.
 - `bspline_path`: basic B-spline path evaluation; run `cargo run --example bspline_path`.
 - `bspline_signal_1d`: 1D signal interpolation with a cubic B-spline; run `cargo run --example bspline_signal_1d`.
+- `bezier_quarter_circle`: cubic Bezier quarter-circle approximation; run `cargo run --example bezier_quarter_circle`.
+- `arc_length_sampling`: equal-arc-length sampling along a Bezier curve; run `cargo run --example arc_length_sampling`.
+- `tangent_normal_curvature`: sample tangent/normal/curvature; run `cargo run --example tangent_normal_curvature`.
 - `plotters_cubic_bezier`: render a cubic Bezier with plotters; run `cargo run --example plotters_cubic_bezier`.
 - `nalgebra_basic`: Bezier with nalgebra SVector; run `cargo run --example nalgebra_basic --features nalgebra`.
   


### PR DESCRIPTION
- bump crate metadata to 0.3.0 and update dependency versions
- add detailed changelog and include it in the published package
- document nightly toolchain usage and expand README example list